### PR TITLE
Suggested Velocity and Backblast Changes

### DIFF
--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -1,22 +1,106 @@
 class CfgAmmo {
-    // Base Classes
-    class ammo_Penetrator_Base;
-    class RocketCore;
-    class RocketBase: RocketCore{};
-
     // CUP Inheritances
-    class CUP_R_M72A6_AT: RocketBase {};
+    class CUP_R_M136_AT;
+    class CUP_R_M72A6_AT;
+    class CUP_P_M136_AT;
+    class CUP_P_M72A6_AT;
 
-    // M72A9 HEDP Rocket
-    class AMMO(R_M72A9_HEDP): CUP_R_M72A6_AT {
-        hit = 150;
-        indirectHit = 30;
-        indirectHitRange = 5;
-        warheadName = "HE";
-        submunitionAmmo = "CUP_P_M72A6_AT";
-        cost = 100;
+    //// M136
+    // AT4CS-RS
+    class AMMO(R_AT4CS_RS_HEAT): CUP_R_M136_AT {
+        submunitionAmmo = QAMMO(P_AT4CS_RS_AT);
+        typicalSpeed = 220;
+    };
+    // AT4CS LMAW
+    class AMMO(R_AT4CS_LMAW_HEDP): CUP_R_M136_AT {
         explosionEffects = "ATMissileExplosion";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        aiAmmoUsageFlags = 448;
+        cost = 80;
+        explosive = 0.9;
+        indirectHitRange = 3;
+        submunitionAmmo = QAMMO(P_AT4CS_LMAW_AT);
+        typicalSpeed = 235;
+
+    };
+    // AT4CS HP
+    class AMMO(R_AT4CS_HP_HEAT): CUP_R_M136_AT {
+        airLock = 1;
+        allowAgainstInfantry = 0;
+        aiAmmoUsageFlags = 768;
+        cost = 400;
+        submunitionAmmo = QAMMO(P_AT4CS_HP_AT);
+        typicalSpeed = 220;
+    };
+
+    //// M72 Law Variants
+    // M72A7 HEDP Rocket
+    class AMMO(R_M72A7_HEDP): CUP_R_M72A6_AT {
+        EGVAR(frag,metal) = 1060;
+        EGVAR(frag,charge) = 300;
+        EGVAR(frag,gurney_c) = 2806;
+        EGVAR(frag,gurney_k) = 3/5;
+        EGVAR(frag,classes)[] = {"ACE_frag_tiny_HD","ACE_frag_small_HD","ACE_frag_small_HD","ACE_frag_medium_HD"};
+        EGVAR(frag,skip) = 0;
+        EGVAR(frag,force) = 0;
+        allowAgainstInfantry = 1;
+        aiAmmoUsageFlags = 192;
+        cost = 100;
+        hit = 200;
+        explosive = 0.9;
+        indirectHit = 4;
+        indirectHitRange = 3;
+        submunitionAmmo = QAMMO(P_M72A7_AT);
+        typicalSpeed = 200;
+        warheadName = "HEAT";
+    };
+    // M72A8 HEDP Rocket FFE
+    class AMMO(R_M72A8_HEDP): AMMO(R_M72A7_HEDP) {
+        typicalSpeed = 166;
+    };
+    // M72A9 LASM Rocket
+    class AMMO(R_M72A9_HEDP): CUP_R_M72A6_AT {
+        EGVAR(frag,metal) = 1150;
+        EGVAR(frag,charge) = 1000;
+        EGVAR(frag,gurney_c) = 2578;
+        EGVAR(frag,gurney_k) = 3/5;
+        EGVAR(frag,classes)[] = {"ACE_frag_tiny_HD","ACE_frag_small_HD","ACE_frag_small_HD","ACE_frag_medium_HD"};
+        EGVAR(frag,skip) = 0;
+        EGVAR(frag,force) = 0;
         airLock = 0; // maybe 1? determines if AI use against air vehicles
         allowAgainstInfantry = 1;
+        aiAmmoUsageFlags = 192; // if airLock = 1, set to 448
+        cost = 100;
+        hit = 300;
+        explosive = 0.95;
+        indirectHit = 5;
+        indirectHitRange = 5;
+        submunitionAmmo = "";
+        typicalSpeed = 130;
+        warheadName = "HE";
+        explosionEffects = "ATMissileExplosion";
+    };
+    // M72A10 FFE
+    class AMMO(R_M72A10_HEDP): AMMO(R_M72A9_HEDP) {
+        typicalSpeed = 108;
+        explosionEffects = "ATRocketExplosion";
+    };
+
+    //// Submunitions
+    class AMMO(P_M72A7_AT): CUP_P_M72A6_AT {
+        caliber = 10;
+        hit = 235;
+    };
+    class AMMO(P_AT4CS_RS_AT): CUP_P_M136_AT {
+        caliber = 23.333;
+    };
+    class AMMO(P_AT4CS_LMAW_AT): CUP_P_M136_AT {
+        caliber = 10;
+        hit = 225;
+    };
+    class AMMO(P_AT4CS_HP_AT): CUP_P_M136_AT {
+        caliber = 40;
+        hit = 400;
     };
 };

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -50,7 +50,7 @@ class CfgAmmo {
         hit = 200;
         explosive = 0.9;
         indirectHit = 4;
-        indirectHitRange = 3;
+        indirectHitRange = 4;
         submunitionAmmo = QAMMO(P_M72A7_AT);
         typicalSpeed = 200;
         warheadName = "HEAT";
@@ -73,9 +73,9 @@ class CfgAmmo {
         aiAmmoUsageFlags = 192; // if airLock = 1, set to 448
         cost = 100;
         hit = 300;
-        explosive = 0.95;
+        explosive = 1;
         indirectHit = 5;
-        indirectHitRange = 5;
+        indirectHitRange = 8;
         submunitionAmmo = "";
         typicalSpeed = 130;
         warheadName = "HE";

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -3,12 +3,12 @@ class CfgAmmo {
     class ammo_Penetrator_Base;
     class RocketCore;
     class RocketBase: RocketCore{};
-    
+
     // CUP Inheritances
     class CUP_R_M72A6_AT: RocketBase {};
-    
+
     // M72A9 HEDP Rocket
-    class potato_R_M72A9_HEDP: CUP_R_M72A6_AT {
+    class AMMO(R_M72A9_HEDP): CUP_R_M72A6_AT {
         hit = 150;
         indirectHit = 30;
         indirectHitRange = 5;

--- a/addons/customGear/launchers/CfgDisposableLaunchers.hpp
+++ b/addons/customGear/launchers/CfgDisposableLaunchers.hpp
@@ -1,4 +1,9 @@
 class CBA_DisposableLaunchers {
     WEAPON(launch_M136A1_CS_Loaded)[] = {QWEAPON(launch_M136A1_CS),QWEAPON(launch_M136A1_CS_Used)};
+    WEAPON(launch_AT4CS_LMAW_Loaded)[] = {QWEAPON(launch_AT4CS_LMAW),QWEAPON(launch_AT4CS_LMAW_Used)};
+    WEAPON(launch_AT4CS_HP_Loaded)[] = {QWEAPON(launch_AT4CS_HP),QWEAPON(launch_AT4CS_HP_Used)};
+    WEAPON(launch_M72A7_Loaded)[] = {QWEAPON(launch_M72A7),QWEAPON(launch_M72A7_Used)};
+    WEAPON(launch_M72A8_Loaded)[] = {QWEAPON(launch_M72A8),QWEAPON(launch_M72A8_Used)};
     WEAPON(launch_M72A9_Loaded)[] = {QWEAPON(launch_M72A9),QWEAPON(launch_M72A9_Used)};
+    WEAPON(launch_M72A10_Loaded)[] = {QWEAPON(launch_M72A10),QWEAPON(launch_M72A10_Used)};
 };

--- a/addons/customGear/launchers/CfgDisposableLaunchers.hpp
+++ b/addons/customGear/launchers/CfgDisposableLaunchers.hpp
@@ -1,0 +1,4 @@
+class CBA_DisposableLaunchers {
+    WEAPON(launch_M136A1_CS_Loaded)[] = {QWEAPON(launch_M136A1_CS),QWEAPON(launch_M136A1_CS_Used)};
+    WEAPON(launch_M72A9_Loaded)[] = {QWEAPON(launch_M72A9),QWEAPON(launch_M72A9_Used)};
+};

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -1,17 +1,67 @@
 class CfgMagazines {
-    // Base Classes
-    class CA_LauncherMagazine;
 
     // CUP Inheritances
-    class CUP_M72A6_M: CA_LauncherMagazine {};
+    class CUP_M136_M;
+    class CUP_M72A6_M;
 
-    // M72A9 HEDP magazine
+    //// M136
+    class MAGAZINE(AT4CS_RS): CUP_M136_M {
+        author = "Potato";
+        ammo = QAMMO(R_AT4CS_RS_HEAT);
+        descriptionShort = "Range: 10m - 200m<br/>Type: HEDP<br/>Used in: AT4CS LMAW";
+        displayName = "AT4CS-RS (HEAT) Rocket";
+        initSpeed = 220;
+        mass = 39.4;
+    };
+    class MAGAZINE(AT4CS_LMAW): CUP_M136_M {
+        author = "Potato";
+        ammo = QAMMO(R_AT4CS_LMAW_HEDP);
+        descriptionShort = "Range: 10m - 200m<br/>Type: HEDP<br/>Used in: AT4CS LMAW";
+        displayName = "AT4CS LMAW (HEDP) Rocket";
+        displayNameShort = "$STR_CUP_DNS_HEDP_M";
+        initSpeed = 235;
+        mass = 39.4;
+    };
+    class MAGAZINE(AT4CS_HP): CUP_M136_M {
+        author = "Potato";
+        ammo = QAMMO(R_AT4CS_HP_HEAT);
+        descriptionShort = "Range: 10m - 300m<br/>Type: HEAT<br/>Used in: AT4CS HP";
+        displayName = "AT4CS HP (HEAT) Rocket";
+        initSpeed = 220;
+        mass = 57;
+    };
+
+    // M72A9 Anti structure Munition magazine
+    class MAGAZINE(M72A7_M): CUP_M72A6_M {
+        author = "Potato";
+        ammo = QAMMO(R_M72A7_HEDP);
+        descriptionShort = "Range: 0 - 350m<br/>Type: HEDP<br/>Used in: M72A7";
+        displayName = "M72A7 (HEDP) Rocket";
+        displayNameShort = "$STR_CUP_DNS_HEDP_M";
+        initSpeed = 200;
+        mass = 29.8;
+    };
+    class MAGAZINE(M72A8_M): MAGAZINE(M72A7_M) {
+        ammo = QAMMO(R_M72A8_HEDP);
+        descriptionShort = "Range: 25 - 350m<br/>Type: HEDP<br/>Used in: M72A8";
+        displayname = "M72A8 (HEDP, FFE) Rocket";
+        initSpeed = 166;
+        mass = 62.8;
+    };
     class MAGAZINE(M72A9_M): CUP_M72A6_M {
-        scope = 2;
         author = "Potato";
         ammo = QAMMO(R_M72A9_HEDP);
-        descriptionshort = "Range: 0 - 200 m<br/>Type: HEDP<br/>Used in: M72A9";
-        displayname = "M72A9 (HEDP) Rocket";
-        displaynameshort = "$STR_A3_HEAT_0"; // swap to HEDP?
+        descriptionShort = "Range: 0 - 200 m<br/>Type: HEDP<br/>Used in: M72A9";
+        displayName = "M72A9 (LASM) Rocket";
+        displaynameshort = "$STR_CUP_DNS_NE_M";
+        initSpeed = 130;
+        mass = 47.4;
+    };
+    class MAGAZINE(M72A10_M): MAGAZINE(M72A9_M) {
+        ammo = QAMMO(R_M72A10_HEDP);
+        descriptionShort = "Range: 25 - 200m<br/>Type: HEDP<br/>Used in: M72A10";
+        displayName = "M72A10 (LASM, FFE) Rocket";
+        initSpeed = 108;
+        mass = 80.4;
     };
 };

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -1,15 +1,15 @@
 class CfgMagazines {
     // Base Classes
     class CA_LauncherMagazine;
-    
+
     // CUP Inheritances
     class CUP_M72A6_M: CA_LauncherMagazine {};
-    
+
     // M72A9 HEDP magazine
-    class potato_M72A9_M: CUP_M72A6_M {
+    class MAGAZINE(M72A9_M): CUP_M72A6_M {
         scope = 2;
         author = "Potato";
-        ammo = "potato_R_M72A9_HEDP";
+        ammo = QAMMO(R_M72A9_HEDP);
         descriptionshort = "Range: 0 - 200 m<br/>Type: HEDP<br/>Used in: M72A9";
         displayname = "M72A9 (HEDP) Rocket";
         displaynameshort = "$STR_A3_HEAT_0"; // swap to HEDP?

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -241,8 +241,9 @@ class CfgWeapons {
         ACEGVAR(overpressure,damage) = 0;
         ACEGVAR(overpressure,range) = 0;
         author = "Potato";
-        discreteDistance[] = {50,100,150};
-        discreteDistanceCameraPoint[] = {"eye_1","eye_3","eye_4"};
+        discreteDistance[] = {50,75,100,150};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_2","eye_3","eye_4"};
+        discreteDistanceInitIndex = 1;
         scope = 1;
         scopeArsenal = 1;
         displayName = "M72A10 (LASM, FFE)";

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -19,18 +19,21 @@ class CfgWeapons {
     class CUP_launch_M72A6: CUP_launch_M72A6_Loaded {};
     class CUP_launch_M72A6_Used: CUP_launch_M72A6_Loaded {};
 
-    // M136 AT4 Confined Space-Reduced Sensitivity
+    //// M136 (AT4) Variants
+    // M136A1 AT4 Confined Space-Reduced Sensitivity
     class WEAPON(launch_M136A1_CS_Loaded): CUP_launch_M136_Loaded {
         author = "Potato";
         scope = 1;
         scopeArsenal = 1;
+        discreteDistance[] = {50,100,150,200,250};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_2","eye_4","eye_6","eye_8"};
         displayName = "M136A1 CS-RS";
-        baseWeapon = QWEAPON(launch_M136A1_CS_Loaded);
+        baseWeapon = QWEAPON(launch_M136A1_CS);
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
-        AGM_UsedTube = "AGM_launch_M136_Used_F";
-        ace_overpressure_angle = 10;
-        ace_overpressure_damage = 0.5;
-        ace_overpressure_range = 4;
+        ACEGVAR(overpressure,angle) = 45;
+        ACEGVAR(overpressure,damage) = 0.8;
+        ACEGVAR(overpressure,range) = 1;
+        magazines[] = {QMAGAZINE(AT4CS_RS)};
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 177.4;
         };
@@ -51,35 +54,169 @@ class CfgWeapons {
     class WEAPON(launch_M136A1_CS_Used): WEAPON(launch_M136A1_CS_Loaded) {
         author = "Potato";
         displayName = "M136A1 CS-RS (Used)";
-        scope = 1;
         baseWeapon = QWEAPON(launch_M136A1_CS_Used);
         model = "\CUP\Weapons\CUP_Weapons_M136\CUP_AT4_used.p3d";
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 117.4;
+            mass = 108;
         };
     };
+    // AT4 Confined Space Light Multipurpose Assault Weapon
+    class WEAPON(launch_AT4CS_LMAW_Loaded): CUP_launch_M136_Loaded {
+        ACEGVAR(overpressure,angle) = 45;
+        ACEGVAR(overpressure,damage) = 0.8;
+        ACEGVAR(overpressure,range) = 1;
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        discreteDistance[] = {50,100,150,200,250};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_2","eye_4","eye_6","eye_8"};
+        displayName = "AT4CS LMAW";
+        baseWeapon = QWEAPON(launch_AT4CS_LMAW);
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {QMAGAZINE(AT4CS_RS)};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 108;
+        };
+        class EventHandlers: EventHandlers {};
+    };
+    class WEAPON(launch_AT4CS_LMAW): WEAPON(launch_AT4CS_LMAW_Loaded) {
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 147.4;
+        };
+    };
+    class WEAPON(launch_AT4CS_LMAW_Used): WEAPON(launch_AT4CS_LMAW_Loaded) {
+        displayName = "AT4CS LMAW (Used)";
+        baseWeapon = QWEAPON(launch_AT4CS_LMAW_Used);
+        model = "\CUP\Weapons\CUP_Weapons_M136\CUP_AT4_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 108;
+        };
+    };
+    // AT4 Confined Space High Penetration
+    class WEAPON(launch_AT4CS_HP_Loaded): CUP_launch_M136_Loaded {
+        ACEGVAR(overpressure,angle) = 45;
+        ACEGVAR(overpressure,damage) = 0.8;
+        ACEGVAR(overpressure,range) = 1;
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        discreteDistance[] = {50,100,150,200,250};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_2","eye_4","eye_6","eye_8"};
+        displayName = "AT4CS HP";
+        baseWeapon = QWEAPON(launch_AT4CS_HP);
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {QMAGAZINE(AT4CS_HP)};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 108;
+        };
+        class EventHandlers: EventHandlers {};
+    };
+    class WEAPON(launch_AT4CS_HP): WEAPON(launch_AT4CS_HP_Loaded) {
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 165;
+        };
+    };
+    class WEAPON(launch_AT4CS_HP_Used): WEAPON(launch_AT4CS_HP_Loaded) {
+        displayName = "AT4CS HP (Used)";
+        baseWeapon = QWEAPON(launch_AT4CS_HP_Used);
+    };
 
+    //// M72 LAW Variants
+    // M72A7 (HEDP)
+    class WEAPON(launch_M72A7_Loaded): CUP_launch_M72A6_Loaded {
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        displayName = "M72A7";
+        baseWeapon = QWEAPON(launch_M72A7_Loaded);
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {QMAGAZINE(M72A7_M)};
+        descriptionShort = "High Explosive Dual Purpose<br/>Unguided";
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 47.2;
+        };
+        class EventHandlers: EventHandlers {};
+    };
+    class WEAPON(launch_M72A7): WEAPON(launch_M72A7_Loaded) {
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 77;
+        };
+    };
+    class WEAPON(launch_M72A7_Used): WEAPON(launch_M72A7_Loaded) {
+        displayName = "M72A7 (Used)";
+        baseWeapon = QWEAPON(launch_M72A7_Used);
+        model = "\CUP\Weapons\CUP_Weapons_M72A6\CUP_m72a6_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 47.2;
+        };
+    };
+    // M72A8 (High Explosive Dual-Purpose, Fire From Enclosure)
+    class WEAPON(launch_M72A8_Loaded): CUP_launch_M72A6_Loaded {
+        ACEGVAR(overpressure,damage) = 0;
+        ACEGVAR(overpressure,range) = 0;
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        displayName = "M72A8 (FFE)";
+        baseWeapon = QWEAPON(launch_M72A8_Loaded);
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {QMAGAZINE(M72A8_M)};
+        descriptionShort = "High Explosive Dual Purpose<br/>Fire From Enclosure<br/>Unguided";
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 47.2;
+        };
+        class EventHandlers: EventHandlers {};
+    };
+    class WEAPON(launch_M72A8): WEAPON(launch_M72A8_Loaded) {
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 110;
+        };
+    };
+    class WEAPON(launch_M72A8_Used): WEAPON(launch_M72A8_Loaded) {
+        displayName = "M72A8 (FFE, Used)";
+        baseWeapon = QWEAPON(launch_M72A8_Used);
+        model = "\CUP\Weapons\CUP_Weapons_M72A6\CUP_m72a6_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 47.2;
+        };
+    };
     // M72A9 (Light Anti-Structure Munition)
     class WEAPON(launch_M72A9_Loaded): CUP_launch_M72A6_Loaded {
         author = "Potato";
+        discreteDistance[] = {50,100,150};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_2","eye_4"};
         scope = 1;
         scopeArsenal = 1;
         displayName = "M72A9 (LASM)";
         baseWeapon = QWEAPON(launch_M72A9_Loaded);
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
         magazines[] = {QMAGAZINE(M72A9_M)};
-        descriptionShort = "Anti-structure missile launcher <br/>Unguided";
+        descriptionShort = "Anti-structure missile launcher<br/>Unguided";
         class WeaponSlotsInfo: WeaponSlotsInfo {
             allowedSlots[] = {901};
-			mass = 94.6;
+            mass = 47.4;
         };
-        class EventHandlers {
-            fired = "_this call CBA_fnc_firedDisposable";
-        };
+        class EventHandlers: EventHandlers {};
     };
     class WEAPON(launch_M72A9): WEAPON(launch_M72A9_Loaded) {
         author = "Potato";
+        maxRange = 150;
         baseWeapon = QWEAPON(launch_M72A9);
         scope = 2;
         scopeArsenal = 2;
@@ -97,6 +234,44 @@ class CfgWeapons {
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 72.4;
+        };
+    };
+    // M72A10 (Light Anti-Structure Munition, Fire From Enclosure)
+    class WEAPON(launch_M72A10_Loaded): CUP_launch_M72A6_Loaded {
+        ACEGVAR(overpressure,damage) = 0;
+        ACEGVAR(overpressure,range) = 0;
+        author = "Potato";
+        discreteDistance[] = {50,100,150};
+        discreteDistanceCameraPoint[] = {"eye_1","eye_3","eye_4"};
+        scope = 1;
+        scopeArsenal = 1;
+        displayName = "M72A10 (LASM, FFE)";
+        baseWeapon = QWEAPON(launch_M72A10_Loaded);
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {QMAGAZINE(M72A10_M)};
+        descriptionShort = "Light Anti-Structure Munition<br/>Fire From Enclosure<br/>Unguided";
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            allowedSlots[] = {901};
+            mass = 47.2;
+        };
+        class EventHandlers: EventHandlers {};
+    };
+    class WEAPON(launch_M72A10): WEAPON(launch_M72A10_Loaded) {
+        maxRange = 100;
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 127.6;
+        };
+    };
+    class WEAPON(launch_M72A10_Used): WEAPON(launch_M72A10_Loaded) {
+        displayName = "M72A10 (HEDP, FFE) (Used)";
+        baseWeapon = QWEAPON(launch_M72A10_Used);
+        model = "\CUP\Weapons\CUP_Weapons_M72A6\CUP_m72a6_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 47.2;
         };
     };
 };

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons {
     class Launcher_Base_F: Launcher {
         class WeaponSlotsInfo;
     };
-    
+
     // CUP Inheritances
     class CUP_launch_M136_Loaded: Launcher_Base_F {
         class WeaponSlotsInfo;
@@ -18,14 +18,14 @@ class CfgWeapons {
     };
     class CUP_launch_M72A6: CUP_launch_M72A6_Loaded {};
     class CUP_launch_M72A6_Used: CUP_launch_M72A6_Loaded {};
-    
+
     // M136 AT4 Confined Space-Reduced Sensitivity
-    class potato_launch_M136A1_CS_Loaded: CUP_launch_M136_Loaded {
+    class WEAPON(launch_M136A1_CS_Loaded): CUP_launch_M136_Loaded {
         author = "Potato";
         scope = 1;
         scopeArsenal = 1;
         displayName = "M136A1 CS-RS";
-        baseWeapon = "potato_launch_M136A1_CS_Loaded";
+        baseWeapon = QWEAPON(launch_M136A1_CS_Loaded);
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
         AGM_UsedTube = "AGM_launch_M136_Used_F";
         ace_overpressure_angle = 10;
@@ -38,9 +38,9 @@ class CfgWeapons {
             fired = "_this call CBA_fnc_firedDisposable";
         };
     };
-    class potato_launch_M136A1_CS: potato_launch_M136A1_CS_Loaded {
+    class WEAPON(launch_M136A1_CS): WEAPON(launch_M136A1_CS_Loaded) {
         author = "Potato";
-        baseWeapon = "potato_launch_M136A1_CS";
+        baseWeapon = QWEAPON(launch_M136A1_CS);
         scope = 2;
         scopeArsenal = 2;
         magazines[] = {"CBA_FakeLauncherMagazine"};
@@ -48,27 +48,27 @@ class CfgWeapons {
             mass = 177.4;
         };
     };
-    class potato_launch_M136A1_CS_Used: potato_launch_M136A1_CS_Loaded {
+    class WEAPON(launch_M136A1_CS_Used): WEAPON(launch_M136A1_CS_Loaded) {
         author = "Potato";
         displayName = "M136A1 CS-RS (Used)";
         scope = 1;
-        baseWeapon = "potato_launch_M136A1_CS_Used";
+        baseWeapon = QWEAPON(launch_M136A1_CS_Used);
         model = "\CUP\Weapons\CUP_Weapons_M136\CUP_AT4_used.p3d";
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 117.4;
         };
     };
-    
+
     // M72A9 (Light Anti-Structure Munition)
-    class potato_launch_M72A9_Loaded: CUP_launch_M72A6_Loaded {
+    class WEAPON(launch_M72A9_Loaded): CUP_launch_M72A6_Loaded {
         author = "Potato";
         scope = 1;
         scopeArsenal = 1;
         displayName = "M72A9 (LASM)";
-        baseWeapon = "potato_launch_M72A9_Loaded";
+        baseWeapon = QWEAPON(launch_M72A9_Loaded);
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
-        magazines[] = {"potato_M72A9_M"};
+        magazines[] = {QMAGAZINE(M72A9_M)};
         descriptionShort = "Anti-structure missile launcher <br/>Unguided";
         class WeaponSlotsInfo: WeaponSlotsInfo {
             allowedSlots[] = {901};
@@ -78,9 +78,9 @@ class CfgWeapons {
             fired = "_this call CBA_fnc_firedDisposable";
         };
     };
-    class potato_launch_M72A9: potato_launch_M72A9_Loaded {
+    class WEAPON(launch_M72A9): WEAPON(launch_M72A9_Loaded) {
         author = "Potato";
-        baseWeapon = "potato_launch_M72A9";
+        baseWeapon = QWEAPON(launch_M72A9);
         scope = 2;
         scopeArsenal = 2;
         magazines[] = {"CBA_FakeLauncherMagazine"};
@@ -88,11 +88,11 @@ class CfgWeapons {
             mass = 94.6;
         };
     };
-    class potato_launch_M72A9_Used: potato_launch_M72A9_Loaded {
+    class WEAPON(launch_M72A9_Used): WEAPON(launch_M72A9_Loaded) {
         author = "Potato";
         displayName = "M72A9 (LASM) (Used)";
         scope = 1;
-        baseWeapon = "potato_launch_M72A9_Used";
+        baseWeapon = QWEAPON(launch_M72A9_Used);
         model = "\CUP\Weapons\CUP_Weapons_M72A6\CUP_m72a6_used.p3d";
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -9,16 +9,12 @@ class CfgPatches {
     class ADDON {
         units[] = {};
         weapons[] = {
-            QWEAPON(launch_M136A1_CS_Loaded),
-            QWEAPON(launch_M136A1_CS),
-            QWEAPON(launch_M136A1_CS_Used),
-            QWEAPON(launch_M72A9_Loaded),
-            QWEAPON(launch_M72A9),
-            QWEAPON(launch_M72A9_Used),
+            WEAPONS_PATCHES(M136A1_CS),
             WEAPONS_PATCHES(AT4CS_LMAW),
             WEAPONS_PATCHES(AT4CS_HP),
             WEAPONS_PATCHES(M72A7),
             WEAPONS_PATCHES(M72A8),
+            WEAPONS_PATCHES(M72A9),
             WEAPONS_PATCHES(M72A10)
         };
         magazines[] = {};

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -15,7 +15,7 @@ class CfgPatches {
         };
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder", "jsrs_soundmod_complete_edition", "jsrs_soundmod_complete_edition_soundFiles" };
+        requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder"};
         skipWhenMissingDependencies = 1;
         author = "Potato";
         authors[] = {"AChesheireCat"};

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -6,12 +6,12 @@ class CfgPatches {
     class ADDON {
         units[] = {};
         weapons[] = {
-            "potato_launch_M136A1_CS_Loaded",
-            "potato_launch_M136A1_CS",
-            "potato_launch_M136A1_CS_Used",
-            "potato_launch_M72A9_Loaded",
-            "potato_launch_M72A9",
-            "potato_launch_M72A9_Used"
+            QWEAPON(launch_M136A1_CS_Loaded),
+            QWEAPON(launch_M136A1_CS),
+            QWEAPON(launch_M136A1_CS_Used),
+            QWEAPON(launch_M72A9_Loaded),
+            QWEAPON(launch_M72A9),
+            QWEAPON(launch_M72A9_Used)
         };
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
@@ -24,11 +24,8 @@ class CfgPatches {
     };
 };
 
-class CBA_DisposableLaunchers {
-    potato_launch_M136A1_CS_Loaded[] = {"potato_launch_M136A1_CS","potato_launch_M136A1_CS_Used"};
-    potato_launch_M72A9_Loaded[] = {"potato_launch_M72A9","potato_launch_M72A9_Used"};
-};
 
-#include "CfgWeapons.hpp"
 #include "CfgAmmo.hpp"
+#include "CfgDisposableLaunchers.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -1,6 +1,9 @@
 #include "\z\potato\addons\customGear\script_component.hpp"
 #undef COMPONENT
 #define COMPONENT customGear_launchers
+#define WEAPONS_PATCHES(var1) QWEAPON(TRIPLES(launch,var1,Loaded)),\
+QWEAPON(DOUBLES(launch,var1)),\
+QWEAPON(TRIPLES(launch,var1,Used))
 
 class CfgPatches {
     class ADDON {
@@ -11,19 +14,23 @@ class CfgPatches {
             QWEAPON(launch_M136A1_CS_Used),
             QWEAPON(launch_M72A9_Loaded),
             QWEAPON(launch_M72A9),
-            QWEAPON(launch_M72A9_Used)
+            QWEAPON(launch_M72A9_Used),
+            WEAPONS_PATCHES(AT4CS_LMAW),
+            WEAPONS_PATCHES(AT4CS_HP),
+            WEAPONS_PATCHES(M72A7),
+            WEAPONS_PATCHES(M72A8),
+            WEAPONS_PATCHES(M72A10)
         };
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder"};
         skipWhenMissingDependencies = 1;
         author = "Potato";
-        authors[] = {"AChesheireCat"};
+        authors[] = {"AChesheireCat", "Lambda.Tiger"};
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;
     };
 };
-
 
 #include "CfgAmmo.hpp"
 #include "CfgDisposableLaunchers.hpp"

--- a/addons/customGear/script_component.hpp
+++ b/addons/customGear/script_component.hpp
@@ -17,5 +17,7 @@
 #define QMAGAZINE(var1) QUOTE(MAGAZINE(var1))
 #define MAGWELL(var1) DOUBLES(PREFIX,var1)
 #define QMAGWELL(var1) QUOTE(MAGWELL(var1))
+#define WEAPON(var1) DOUBLES(PREFIX,var1)
+#define QWEAPON(var1) QUOTE(WEAPON(var1))
 
 #define MAGWELL_ENTRY_NAME DOUBLES(PREFIX,magazineWell)

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -426,16 +426,6 @@ class CfgWeapons {
             "CUP_200Rnd_TE1_Red_Tracer_127x99_M"
         };
     };
-    
-    class Launcher;
-    class Launcher_Base_F: Launcher {
-        class WeaponSlotsInfo;
-    };
-    class CUP_launch_M136_Loaded: Launcher_Base_F {
-        ace_overpressure_angle = 45;
-        ace_overpressure_damage = 0.5;
-        ace_overpressure_range = 50; // increasing range due to reduction in "lethal" damage - original 10m was described as "lethal", irl total backblast range listed as 100m
-    };
 };
 
 class SlotInfo;


### PR DESCRIPTION
Sorry this was in my WIP folder before you submitted so I finished things. This PR suggest changes to

- Misc formatting fixes
- Change backblast on the M136A1CS-RS
- Returned backblast on M136 to previous settings
  - ACE's simulation is really only of Danger Zone "A", which is 5m in radius
![image](https://github.com/user-attachments/assets/86b12fbc-3371-46d4-bffd-8f3240a0cab9)
- Change initial velocity on M136A1CS-RS and M72A9
- Remove submunition penetrator form M72A9 (Nammo calls it a thermobaric HE round)
- Lower penetration on M136A1CS-RS to align with spec
- Add M72A7, M72A8 and M72A10, AT4CS HP, and AT4CS LMAW